### PR TITLE
Release/v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,30 @@ TestAA.Act(() => int.Parse("123")).Assert(
 
 ### Task Synchronously
 ```cs
+// Task
 TestAA.Act(() => Task.FromResult(123)).Assert(123);
+
+// ValueTask
+TestAA.Act(() => new ValueTask<int>(123)).Assert(123);
 ```
 
 ### Task Throws Exception
 ```cs
+// Task
 TestAA.Act(() => Task.FromException(new ApplicationException())).Assert<ApplicationException>();
+
+// ValueTask
+TestAA.Act(() => new ValueTask(Task.FromException(new ApplicationException()))).Assert<ApplicationException>();
 ```
 
 ### Raw Task
 ```cs
+// Task
 var task = Task.FromResult(123);
 TestAA.Act<Task<int>>(() => task).Assert(task);
+
+// ValueTask
+TestAA.Act<ValueTask<int>>(() => new ValueTask<int>(123)).Assert(new ValueTask<int>(123));
 ```
 
 ### Immediate Enumerable Evaluation

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ TestAA.Act(() => { /* ここでテスト対象のメソッドを呼ぶ */ })
 検証はラムダ式やデリゲートではなく値を直接入力する事でも可能です。テストの失敗は、既定では `TestAssertFailedException` のスローによって通知されます。
 ```cs
 TestAA.Act(() => int.Parse("123")).Assert(123);  // OK
-TestAA.Act(() => int.Parse("abc")).Assert(ret => { }, new FormatException());  // OK
+TestAA.Act(() => int.Parse("abc")).Assert<FormatException>();  // OK
 TestAA.Act(() => int.Parse("abc")).Assert(123);  // TestAssertFailedException
 ```
 
@@ -59,7 +59,7 @@ TestAA.Act(() => int.Parse("123")).Assert(123);
 ```
 ### Throws Exception
 ```cs
-TestAA.Act(() => int.Parse("abc")).Assert(ret => { }, exception: new FormatException());
+TestAA.Act(() => int.Parse("abc")).Assert<FormatException>();
 ```
 
 ### Out Parameter
@@ -86,7 +86,7 @@ TestAA.Act(() => Task.FromResult(123)).Assert(123);
 
 ### Task Throws Exception
 ```cs
-TestAA.Act(() => Task.FromException(new ApplicationException())).Assert(new ApplicationException());
+TestAA.Act(() => Task.FromException(new ApplicationException())).Assert<ApplicationException>();
 ```
 
 ### Raw Task
@@ -97,7 +97,7 @@ TestAA.Act<Task<int>>(() => task).Assert(task);
 
 ### Immediate Enumerable Evaluation
 ```cs
-TestAA.Act(() => CreateEnumerable()).Assert(ret => { }, new ApplicationException());
+TestAA.Act(() => CreateEnumerable()).Assert<ApplicationException>();
 
 IEnumerable<int> CreateEnumerable() {
     yield return 123;
@@ -120,15 +120,15 @@ TestAA.Act(() => int.Parse("123")).Assert(123);  // Assert.AreEqual()
 
 ### Test Cases
 ```cs
-Action TestCase(int testNumber, string input, int expected, Exception expectedException = null) => () => {
+Action TestCase(int testNumber, string input, int expected, Type expectedException = null) => () => {
     var msg = "No." + testNumber;
 
     TestAA.Act(() => int.Parse(input)).Assert(expected, expectedException, msg);
 };
 
 foreach (var action in new[] {
-    TestCase( 0, null , expected: 0  , expectedException: new ArgumentNullException()),
-    TestCase( 1, "abc", expected: 0  , expectedException: new FormatException()),
+    TestCase( 0, null , expected: 0  , expectedException: typeof(ArgumentNullException)),
+    TestCase( 1, "abc", expected: 0  , expectedException: typeof(FormatException)),
     TestCase( 2, "123", expected: 123),
 }) { action(); }
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,6 @@ deploy:
     appveyor_repo_tag: true
 - provider: NuGet
   api_key:
-    secure: 5auKjaKm29nXAKSDhhZOM1V+1H+MsUwIRi8xw+vZa4t9rlhg2hHX+BExGh/8XOAd
+    secure: LAo0c9SiVqvPguwNcKUMbQGnMMYq6s0QhvXHrwfZyN8djLKimZB7pbykxIAiNcFH
   on:
     appveyor_repo_tag: true

--- a/src/Inasync.TestAA/Inasync.TestAA.csproj
+++ b/src/Inasync.TestAA/Inasync.TestAA.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://github.com/in-async/TestAA</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/in-async/TestAA/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>library test unittest AAA</PackageTags>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Inasync.TestAA/Inasync.TestAA.csproj
+++ b/src/Inasync.TestAA/Inasync.TestAA.csproj
@@ -12,4 +12,8 @@
     <Version>0.3.0</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/Inasync.TestAA/TestAA.Act.cs
+++ b/src/Inasync.TestAA/TestAA.Act.cs
@@ -51,12 +51,37 @@ namespace Inasync {
     public static partial class TestAA {
 
         /// <summary>
+        /// テスト対象のデリゲートを実行し、戻り値のシーケンスを配列化します。
+        /// </summary>
+        /// <typeparam name="TItem">テスト対象のデリゲートが戻り値とするシーケンスの要素の型。</typeparam>
+        /// <param name="act">テスト対象のデリゲート。</param>
+        /// <returns>デリゲートの実行結果。</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="act"/> is <c>null</c>.</exception>
+        public static TestActual<TItem[]> Act<TItem>(Func<IEnumerable<TItem>> act) {
+            if (act == null) { throw new ArgumentNullException(nameof(act)); }
+
+            return Act(() => act().ToArray());
+        }
+
+        /// <summary>
         /// テスト対象の非同期デリゲートを同期的に実行します。
         /// </summary>
         /// <param name="act">テスト対象の非同期デリゲート。</param>
         /// <returns>非同期デリゲートの実行結果。</returns>
         /// <exception cref="ArgumentNullException"><paramref name="act"/> is <c>null</c>.</exception>
         public static TestActual Act(Func<Task> act) {
+            if (act == null) { throw new ArgumentNullException(nameof(act)); }
+
+            return Act(() => act().GetAwaiter().GetResult());
+        }
+
+        /// <summary>
+        /// テスト対象の非同期デリゲートを同期的に実行します。
+        /// </summary>
+        /// <param name="act">テスト対象の非同期デリゲート。</param>
+        /// <returns>非同期デリゲートの実行結果。</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="act"/> is <c>null</c>.</exception>
+        public static TestActual Act(Func<ValueTask> act) {
             if (act == null) { throw new ArgumentNullException(nameof(act)); }
 
             return Act(() => act().GetAwaiter().GetResult());
@@ -76,16 +101,16 @@ namespace Inasync {
         }
 
         /// <summary>
-        /// テスト対象のデリゲートを実行し、戻り値のシーケンスを配列化します。
+        /// テスト対象の非同期デリゲートを同期的に実行します。
         /// </summary>
-        /// <typeparam name="TItem">テスト対象のデリゲートが戻り値とするシーケンスの要素の型。</typeparam>
-        /// <param name="act">テスト対象のデリゲート。</param>
-        /// <returns>デリゲートの実行結果。</returns>
+        /// <typeparam name="TReturn">テスト対象の非同期デリゲートの戻り値の型。</typeparam>
+        /// <param name="act">テスト対象の非同期デリゲート。</param>
+        /// <returns>非同期デリゲートの実行結果。</returns>
         /// <exception cref="ArgumentNullException"><paramref name="act"/> is <c>null</c>.</exception>
-        public static TestActual<TItem[]> Act<TItem>(Func<IEnumerable<TItem>> act) {
+        public static TestActual<TReturn> Act<TReturn>(Func<ValueTask<TReturn>> act) {
             if (act == null) { throw new ArgumentNullException(nameof(act)); }
 
-            return Act(() => act().ToArray());
+            return Act(() => act().GetAwaiter().GetResult());
         }
 
         /// <summary>
@@ -96,6 +121,19 @@ namespace Inasync {
         /// <returns>非同期デリゲートの実行結果。</returns>
         /// <exception cref="ArgumentNullException"><paramref name="act"/> is <c>null</c>.</exception>
         public static TestActual<TItem[]> Act<TItem>(Func<Task<IEnumerable<TItem>>> act) {
+            if (act == null) { throw new ArgumentNullException(nameof(act)); }
+
+            return Act(() => act().GetAwaiter().GetResult().ToArray());
+        }
+
+        /// <summary>
+        /// テスト対象の非同期デリゲートを同期的に実行し、戻り値のシーケンスを配列化します。
+        /// </summary>
+        /// <typeparam name="TItem">テスト対象の非同期デリゲートが戻り値とするシーケンスの要素の型。</typeparam>
+        /// <param name="act">テスト対象の非同期デリゲート。</param>
+        /// <returns>非同期デリゲートの実行結果。</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="act"/> is <c>null</c>.</exception>
+        public static TestActual<TItem[]> Act<TItem>(Func<ValueTask<IEnumerable<TItem>>> act) {
             if (act == null) { throw new ArgumentNullException(nameof(act)); }
 
             return Act(() => act().GetAwaiter().GetResult().ToArray());

--- a/src/Inasync.TestAA/TestActual.Assert.cs
+++ b/src/Inasync.TestAA/TestActual.Assert.cs
@@ -19,13 +19,25 @@ namespace Inasync {
         /// Act の実行結果を検証します。
         /// </summary>
         /// <param name="exception">
-        /// Act で生じる事が予期される例外。例外が生じない事が予期される場合は <c>null</c>。
+        /// Act で生じる事が予期される例外の型。例外が生じない事が予期される場合は <c>null</c>。
         /// <see cref="TestAA.TestAssert"/> によって実際の例外と比較されます。
         /// </param>
         /// <param name="message">テスト失敗時に結果に表示されるメッセージ。</param>
-        public void Assert(Exception exception = null, string message = null) {
+        public void Assert(Type exception = null, string message = null) {
             var actual = this;
             Assert(ex => TestAA.TestAssert.AssertException(actual.Exception, exception, message));
+        }
+
+        /// <summary>
+        /// Act の実行結果を検証します。
+        /// </summary>
+        /// <typeparam name="TException">
+        /// Act で生じる事が予期される例外の型。
+        /// <see cref="Assert(Type, string)"/> によって実際の例外と比較されます。
+        /// </typeparam>
+        /// <param name="message">テスト失敗時に結果に表示されるメッセージ。</param>
+        public void Assert<TException>(string message = null) where TException : Exception {
+            Assert(exception: typeof(TException), message: message);
         }
     }
 
@@ -55,12 +67,12 @@ namespace Inasync {
         /// </summary>
         /// <param name="return">Act の戻り値を検証するデリゲート。Act で例外が生じた場合は呼ばれません。</param>
         /// <param name="exception">
-        /// Act で生じる事が予期される例外。例外が生じない事が予期される場合は <c>null</c>。
+        /// Act で生じる事が予期される例外の型。例外が生じない事が予期される場合は <c>null</c>。
         /// <see cref="TestAA.TestAssert"/> によって実際の例外と比較されます。
         /// </param>
         /// <param name="message">テスト失敗時に結果に表示されるメッセージ。</param>
         /// <exception cref="ArgumentNullException"><paramref name="return"/> is <c>null</c>.</exception>
-        public void Assert(Action<TReturn> @return, Exception exception = null, string message = null) {
+        public void Assert(Action<TReturn> @return, Type exception = null, string message = null) {
             var actual = this;
             Assert(
                   @return
@@ -77,16 +89,44 @@ namespace Inasync {
         /// Act で例外が生じた場合は比較されません。
         /// </param>
         /// <param name="exception">
-        /// Act で生じる事が予期される例外。例外が生じない事が予期される場合は <c>null</c>。
+        /// Act で生じる事が予期される例外の型。例外が生じない事が予期される場合は <c>null</c>。
         /// <see cref="TestAA.TestAssert"/> によって実際の例外と比較されます。
         /// </param>
         /// <param name="message">テスト失敗時に結果に表示されるメッセージ。</param>
-        public void Assert(TReturn @return, Exception exception = null, string message = null) {
+        public void Assert(TReturn @return, Type exception = null, string message = null) {
             var actual = this;
             Assert(
                   ret => TestAA.TestAssert.Is(actual.Return, @return, message)
                 , ex => TestAA.TestAssert.AssertException(actual.Exception, exception, message)
             );
+        }
+
+        /// <summary>
+        /// Act の実行結果を検証します。
+        /// </summary>
+        /// <param name="exception">
+        /// Act で生じる事が予期される例外の型。例外が生じない事が予期される場合は <c>null</c>。
+        /// <see cref="TestAA.TestAssert"/> によって実際の例外と比較されます。
+        /// </param>
+        /// <param name="message">テスト失敗時に結果に表示されるメッセージ。</param>
+        public void Assert(Type exception = null, string message = null) {
+            var actual = this;
+            Assert(
+                  ret => { }
+                , ex => TestAA.TestAssert.AssertException(actual.Exception, exception, message)
+            );
+        }
+
+        /// <summary>
+        /// Act の実行結果を検証します。
+        /// </summary>
+        /// <typeparam name="TException">
+        /// Act で生じる事が予期される例外の型。
+        /// <see cref="Assert(Type, string)"/> によって実際の例外と比較されます。
+        /// </typeparam>
+        /// <param name="message">テスト失敗時に結果に表示されるメッセージ。</param>
+        public void Assert<TException>(string message = null) where TException : Exception {
+            Assert(exception: typeof(TException), message: message);
         }
     }
 }

--- a/src/Inasync.TestAA/TestAssert.cs
+++ b/src/Inasync.TestAA/TestAssert.cs
@@ -37,20 +37,20 @@ namespace Inasync {
         }
 
         /// <summary>
-        /// 2 つの例外が等しいかどうかのテストを行います。
+        /// 生じた例外が予期した型かどうかのテストを行います。
         /// </summary>
         /// <remarks>
         /// 既定では、2 つの例外の型を <see cref="Is{TReturn}(TReturn, TReturn, string)"/> によって比較します。
         /// </remarks>
         /// <param name="actual">実際の例外。</param>
-        /// <param name="expected">予期している例外。</param>
-        /// <param name="message"><paramref name="actual"/> と <paramref name="expected"/> が等しくない場合にテスト結果に表示されるメッセージ。</param>
-        public virtual void AssertException(Exception actual, Exception expected, string message) {
+        /// <param name="expectedType">予期している例外の型。</param>
+        /// <param name="message"><paramref name="actual"/> の型と <paramref name="expectedType"/> が等しくない場合にテスト結果に表示されるメッセージ。</param>
+        public virtual void AssertException(Exception actual, Type expectedType, string message) {
             var finalMessage = message;
             if (actual != null) {
                 finalMessage += Environment.NewLine + "Actual Exception: " + actual;
             }
-            Is(actual?.GetType(), expected?.GetType(), finalMessage);
+            Is(actual?.GetType(), expectedType, finalMessage);
         }
     }
 

--- a/tests/Inasync.TestAA.Tests/TestAA.Act.Tests.cs
+++ b/tests/Inasync.TestAA.Tests/TestAA.Act.Tests.cs
@@ -70,6 +70,38 @@ namespace Inasync.Tests {
         }
 
         [TestMethod]
+        public void Act_IEnumerable() {
+            Action TestCase(int testNumber, Func<IEnumerable<DummyObject>> act, (DummyObject[] @return, Type exceptionType) expected, Type expectedExceptionType = null) => () => {
+                var msg = "No." + testNumber;
+
+                // Act
+                TestActual<DummyObject[]> testActual = default;
+                Exception exception = null;
+                try {
+                    testActual = TestAA.Act(act);
+                }
+                catch (Exception ex) {
+                    exception = ex;
+                }
+
+                // Assert
+                if (exception == null) {
+                    Assert.AreEqual(expected.exceptionType, testActual.Exception?.GetType(), msg);
+                    CollectionAssert.AreEqual(expected.@return, testActual.Return, msg);
+                }
+                Assert.AreEqual(expectedExceptionType, exception?.GetType(), msg);
+            };
+
+            var obj1 = new DummyObject();
+            var obj2 = new DummyObject();
+            foreach (var action in new[]{
+                TestCase( 0, act: null                            , expected: default                                      , expectedExceptionType: typeof(ArgumentNullException)),
+                TestCase( 1, act: () => new[]{ obj1, obj2 }       , expected: (new[]{ obj1, obj2 }, null)                  ),
+                TestCase( 2, act: () => throw new DummyException(), expected: (null               , typeof(DummyException))),
+            }) { action(); }
+        }
+
+        [TestMethod]
         public void Act_Task() {
             Action TestCase(int testNumber, Func<Task> act, Type exceptionType, Type expectedExceptionType = null) => () => {
                 var msg = "No." + testNumber;
@@ -95,6 +127,36 @@ namespace Inasync.Tests {
             foreach (var action in new[]{
                 TestCase( 0, act: null                            , exceptionType: null                  , expectedExceptionType: typeof(ArgumentNullException)),
                 TestCase( 1, act: () => Task.CompletedTask        , exceptionType: null                  ),
+                TestCase( 2, act: () => throw new DummyException(), exceptionType: typeof(DummyException)),
+            }) { action(); }
+        }
+
+        [TestMethod]
+        public void Act_ValueTask() {
+            Action TestCase(int testNumber, Func<ValueTask> act, Type exceptionType, Type expectedExceptionType = null) => () => {
+                var msg = "No." + testNumber;
+
+                // Act
+                TestActual testActual = default;
+                Exception exception = null;
+                try {
+                    testActual = TestAA.Act(act);
+                }
+                catch (Exception ex) {
+                    exception = ex;
+                }
+
+                // Assert
+                if (exception == null) {
+                    Assert.AreEqual(typeof(TestActual), testActual.GetType(), msg);
+                    Assert.AreEqual(exceptionType, testActual.Exception?.GetType(), msg);
+                }
+                Assert.AreEqual(expectedExceptionType, exception?.GetType(), msg);
+            };
+
+            foreach (var action in new[]{
+                TestCase( 0, act: null                            , exceptionType: null                  , expectedExceptionType: typeof(ArgumentNullException)),
+                TestCase( 1, act: () => default                   , exceptionType: null                  ),
                 TestCase( 2, act: () => throw new DummyException(), exceptionType: typeof(DummyException)),
             }) { action(); }
         }
@@ -131,12 +193,12 @@ namespace Inasync.Tests {
         }
 
         [TestMethod]
-        public void Act_IEnumerable() {
-            Action TestCase(int testNumber, Func<IEnumerable<DummyObject>> act, (DummyObject[] @return, Type exceptionType) expected, Type expectedExceptionType = null) => () => {
+        public void Act_ValueTaskTReturn() {
+            Action TestCase(int testNumber, Func<ValueTask<DummyObject>> act, (DummyObject @return, Type exceptionType) expected, Type expectedExceptionType = null) => () => {
                 var msg = "No." + testNumber;
 
                 // Act
-                TestActual<DummyObject[]> testActual = default;
+                TestActual<DummyObject> testActual = default;
                 Exception exception = null;
                 try {
                     testActual = TestAA.Act(act);
@@ -148,17 +210,16 @@ namespace Inasync.Tests {
                 // Assert
                 if (exception == null) {
                     Assert.AreEqual(expected.exceptionType, testActual.Exception?.GetType(), msg);
-                    CollectionAssert.AreEqual(expected.@return, testActual.Return, msg);
+                    Assert.AreEqual(expected.@return, testActual.Return, msg);
                 }
                 Assert.AreEqual(expectedExceptionType, exception?.GetType(), msg);
             };
 
-            var obj1 = new DummyObject();
-            var obj2 = new DummyObject();
+            var obj = new DummyObject();
             foreach (var action in new[]{
-                TestCase( 0, act: null                            , expected: default                                      , expectedExceptionType: typeof(ArgumentNullException)),
-                TestCase( 1, act: () => new[]{ obj1, obj2 }       , expected: (new[]{ obj1, obj2 }, null)                  ),
-                TestCase( 2, act: () => throw new DummyException(), expected: (null               , typeof(DummyException))),
+                TestCase( 0, act: null                                 , expected: default                       , expectedExceptionType: typeof(ArgumentNullException)),
+                TestCase( 1, act: () => new ValueTask<DummyObject>(obj), expected: (obj , null)                  ),
+                TestCase( 2, act: () => throw new DummyException()     , expected: (null, typeof(DummyException))),
             }) { action(); }
         }
 
@@ -191,6 +252,38 @@ namespace Inasync.Tests {
                 TestCase( 0, act: null                                                                , expected: default                                      , expectedExceptionType: typeof(ArgumentNullException)),
                 TestCase( 1, act: () => Task.FromResult<IEnumerable<DummyObject>>(new[]{ obj1, obj2 }), expected: (new[]{ obj1, obj2 }, null)                  ),
                 TestCase( 2, act: () => throw new DummyException()                                    , expected: (null               , typeof(DummyException))),
+            }) { action(); }
+        }
+
+        [TestMethod]
+        public void Act_ValueTaskIEnumerable() {
+            Action TestCase(int testNumber, Func<ValueTask<IEnumerable<DummyObject>>> act, (DummyObject[] @return, Type exceptionType) expected, Type expectedExceptionType = null) => () => {
+                var msg = "No." + testNumber;
+
+                // Act
+                TestActual<DummyObject[]> testActual = default;
+                Exception exception = null;
+                try {
+                    testActual = TestAA.Act(act);
+                }
+                catch (Exception ex) {
+                    exception = ex;
+                }
+
+                // Assert
+                if (exception == null) {
+                    Assert.AreEqual(expected.exceptionType, testActual.Exception?.GetType(), msg);
+                    CollectionAssert.AreEqual(expected.@return, testActual.Return, msg);
+                }
+                Assert.AreEqual(expectedExceptionType, exception?.GetType(), msg);
+            };
+
+            var obj1 = new DummyObject();
+            var obj2 = new DummyObject();
+            foreach (var action in new[]{
+                TestCase( 0, act: null                                                              , expected: default                                      , expectedExceptionType: typeof(ArgumentNullException)),
+                TestCase( 1, act: () => new ValueTask<IEnumerable<DummyObject>>(new[]{ obj1, obj2 }), expected: (new[]{ obj1, obj2 }, null)                  ),
+                TestCase( 2, act: () => throw new DummyException()                                  , expected: (null               , typeof(DummyException))),
             }) { action(); }
         }
 

--- a/tests/Inasync.TestAA.Tests/TestActual.Assert.Tests.cs
+++ b/tests/Inasync.TestAA.Tests/TestActual.Assert.Tests.cs
@@ -36,13 +36,13 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void Assert_Exception_Message() {
-            Action TestCase(int testNumber, TestActual testActual, Exception exception, Type expectedExceptionType = null) => () => {
+            Action TestCase(int testNumber, TestActual testActual, Type exceptionType, Type expectedExceptionType = null) => () => {
                 var msg = "No." + testNumber;
 
                 // Act
                 Exception exception_ = null;
                 try {
-                    testActual.Assert(exception);
+                    testActual.Assert(exceptionType);
                 }
                 catch (Exception ex_) {
                     exception_ = ex_;
@@ -52,12 +52,35 @@ namespace Inasync.Tests {
                 Assert.AreEqual(expectedExceptionType, exception_?.GetType(), msg);
             };
 
-            var ex = new DummyException();
             foreach (var action in new[]{
-                TestCase( 0, new TestActual(null), null),
-                TestCase( 1, new TestActual(null), ex  , expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 2, new TestActual(ex)  , null, expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 3, new TestActual(ex)  , ex  ),
+                TestCase( 0, new TestActual(null)                , null                 ),
+                TestCase( 1, new TestActual(null)                , typeof(DummyException), expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 2, new TestActual(new DummyException()), null                  , expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 3, new TestActual(new DummyException()), typeof(DummyException)),
+            }) { action(); }
+        }
+
+        [TestMethod]
+        public void Assert_TException_Message() {
+            Action TestCase<TException>(int testNumber, TestActual testActual, Type expectedExceptionType = null) where TException : Exception => () => {
+                var msg = "No." + testNumber;
+
+                // Act
+                Exception exception_ = null;
+                try {
+                    testActual.Assert<TException>();
+                }
+                catch (Exception ex_) {
+                    exception_ = ex_;
+                }
+
+                // Assert
+                Assert.AreEqual(expectedExceptionType, exception_?.GetType(), msg);
+            };
+
+            foreach (var action in new[]{
+                TestCase<DummyException>( 0, new TestActual(null)                , expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase<DummyException>( 1, new TestActual(new DummyException())),
             }) { action(); }
         }
 
@@ -119,13 +142,13 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void Assert_ActionTReturn_Exception_Message() {
-            Action TestCase(int testNumber, TestActual<DummyObject> testActual, AssertReturn @return, Exception exception, DummyObject expectedReturn, Type expectedExceptionType = null) => () => {
+            Action TestCase(int testNumber, TestActual<DummyObject> testActual, AssertReturn @return, Type exceptionType, DummyObject expectedReturn, Type expectedExceptionType = null) => () => {
                 var msg = "No." + testNumber;
 
                 // Act
                 Exception exception_ = null;
                 try {
-                    testActual.Assert(@return?.Invoke, exception);
+                    testActual.Assert(@return?.Invoke, exceptionType);
                 }
                 catch (Exception ex_) {
                     exception_ = ex_;
@@ -137,26 +160,25 @@ namespace Inasync.Tests {
             };
 
             var obj = new DummyObject();
-            var ex = new DummyException();
             foreach (var action in new[]{
-                TestCase( 0, new TestActual<DummyObject>(obj), null              , exception: ex  , expectedReturn: null, expectedExceptionType: typeof(ArgumentNullException)),
-                TestCase( 1, new TestActual<DummyObject>(obj), new AssertReturn(), exception: null, expectedReturn: obj ),
-                TestCase( 2, new TestActual<DummyObject>(obj), new AssertReturn(), exception: ex  , expectedReturn: null, expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 3, new TestActual<DummyObject>(ex ), null              , exception: ex  , expectedReturn: null, expectedExceptionType: typeof(ArgumentNullException)),
-                TestCase( 4, new TestActual<DummyObject>(ex ), new AssertReturn(), exception: null, expectedReturn: null, expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 5, new TestActual<DummyObject>(ex ), new AssertReturn(), exception: ex  , expectedReturn: null),
+                TestCase( 0, new TestActual<DummyObject>(obj                 ), null              , exceptionType: typeof(DummyException), expectedReturn: null, expectedExceptionType: typeof(ArgumentNullException)),
+                TestCase( 1, new TestActual<DummyObject>(obj                 ), new AssertReturn(), exceptionType: null                  , expectedReturn: obj ),
+                TestCase( 2, new TestActual<DummyObject>(obj                 ), new AssertReturn(), exceptionType: typeof(DummyException), expectedReturn: null, expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 3, new TestActual<DummyObject>(new DummyException()), null              , exceptionType: typeof(DummyException), expectedReturn: null, expectedExceptionType: typeof(ArgumentNullException)),
+                TestCase( 4, new TestActual<DummyObject>(new DummyException()), new AssertReturn(), exceptionType: null                  , expectedReturn: null, expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 5, new TestActual<DummyObject>(new DummyException()), new AssertReturn(), exceptionType: typeof(DummyException), expectedReturn: null),
             }) { action(); }
         }
 
         [TestMethod]
         public void Assert_TReturn_Exception_Message() {
-            Action TestCase(int testNumber, TestActual<DummyObject> testActual, DummyObject @return, Exception exception, Type expectedExceptionType = null) => () => {
+            Action TestCase(int testNumber, TestActual<DummyObject> testActual, DummyObject @return, Type exceptionType, Type expectedExceptionType = null) => () => {
                 var msg = "No." + testNumber;
 
                 // Act
                 Exception exception_ = null;
                 try {
-                    testActual.Assert(@return, exception);
+                    testActual.Assert(@return, exceptionType);
                 }
                 catch (Exception ex_) {
                     exception_ = ex_;
@@ -167,14 +189,65 @@ namespace Inasync.Tests {
             };
 
             var obj = new DummyObject();
-            var ex = new DummyException();
             foreach (var action in new[]{
-                TestCase( 0, new TestActual<DummyObject>(obj), @return: null, exception: ex  , expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 1, new TestActual<DummyObject>(obj), @return: obj , exception: null),
-                TestCase( 2, new TestActual<DummyObject>(obj), @return: obj , exception: ex  , expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 3, new TestActual<DummyObject>(ex ), @return: null, exception: ex  ),
-                TestCase( 4, new TestActual<DummyObject>(ex ), @return: obj , exception: null, expectedExceptionType: typeof(TestAssertFailedException)),
-                TestCase( 5, new TestActual<DummyObject>(ex ), @return: obj , exception: ex  ),
+                TestCase( 0, new TestActual<DummyObject>(obj                 ), @return: null, exceptionType: typeof(DummyException), expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 1, new TestActual<DummyObject>(obj                 ), @return: obj , exceptionType: null                 ),
+                TestCase( 2, new TestActual<DummyObject>(obj                 ), @return: obj , exceptionType: typeof(DummyException), expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 3, new TestActual<DummyObject>(new DummyException()), @return: null, exceptionType: typeof(DummyException)),
+                TestCase( 4, new TestActual<DummyObject>(new DummyException()), @return: obj , exceptionType: null                  , expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 5, new TestActual<DummyObject>(new DummyException()), @return: obj , exceptionType: typeof(DummyException)),
+            }) { action(); }
+        }
+
+        [TestMethod]
+        public void Assert_Exception_Message() {
+            Action TestCase(int testNumber, TestActual<DummyObject> testActual, Type exceptionType, Type expectedExceptionType = null) => () => {
+                var msg = "No." + testNumber;
+
+                // Act
+                Exception exception_ = null;
+                try {
+                    testActual.Assert(exceptionType);
+                }
+                catch (Exception ex_) {
+                    exception_ = ex_;
+                }
+
+                // Assert
+                Assert.AreEqual(expectedExceptionType, exception_?.GetType(), msg);
+            };
+
+            var obj = new DummyObject();
+            foreach (var action in new[]{
+                TestCase( 0, new TestActual<DummyObject>(obj                 ), exceptionType: typeof(DummyException), expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase( 1, new TestActual<DummyObject>(obj                 ), exceptionType: null                 ),
+                TestCase( 2, new TestActual<DummyObject>(new DummyException()), exceptionType: typeof(DummyException)),
+                TestCase( 3, new TestActual<DummyObject>(new DummyException()), exceptionType: null                  , expectedExceptionType: typeof(TestAssertFailedException)),
+            }) { action(); }
+        }
+
+        [TestMethod]
+        public void Assert_TException_Message() {
+            Action TestCase<TException>(int testNumber, TestActual<DummyObject> testActual, Type expectedExceptionType = null) where TException : Exception => () => {
+                var msg = "No." + testNumber;
+
+                // Act
+                Exception exception_ = null;
+                try {
+                    testActual.Assert<TException>();
+                }
+                catch (Exception ex_) {
+                    exception_ = ex_;
+                }
+
+                // Assert
+                Assert.AreEqual(expectedExceptionType, exception_?.GetType(), msg);
+            };
+
+            var obj = new DummyObject();
+            foreach (var action in new[]{
+                TestCase<DummyException>( 0, new TestActual<DummyObject>(obj                 ), expectedExceptionType: typeof(TestAssertFailedException)),
+                TestCase<DummyException>( 1, new TestActual<DummyObject>(new DummyException())),
             }) { action(); }
         }
 

--- a/tests/Inasync.TestAA.Tests/TestAssert.Tests.cs
+++ b/tests/Inasync.TestAA.Tests/TestAssert.Tests.cs
@@ -35,13 +35,13 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void AssertException() {
-            Action TestCase(int testNumber, Exception actual, Exception expected, string message, string expectedMessage) => () => {
+            Action TestCase(int testNumber, Exception actual, Type expectedType, string message, string expectedMessage) => () => {
                 var msg = "No." + testNumber;
 
                 // Act
                 Exception exception = null;
                 try {
-                    TestAssert.Default.AssertException(actual, expected, message);
+                    TestAssert.Default.AssertException(actual, expectedType, message);
                 }
                 catch (Exception ex) {
                     exception = ex;
@@ -52,13 +52,12 @@ namespace Inasync.Tests {
             };
 
             var exA = new ApplicationException();
-            var exB = new Exception();
             foreach (var action in new[] {
-                TestCase( 0, actual:exA , expected:exA , message:"M" , expectedMessage: null),
-                TestCase( 1, actual:exA , expected:exB , message:"M" , expectedMessage: string.Format("Assert failed.{0}Expected: <System.Exception>{0}Actual: <System.ApplicationException>{0}M{0}Actual Exception: " + exA, Environment.NewLine)),
-                TestCase( 2, actual:exA , expected:exB , message:null, expectedMessage: string.Format("Assert failed.{0}Expected: <System.Exception>{0}Actual: <System.ApplicationException>{0}{0}Actual Exception: " + exA, Environment.NewLine)),
-                TestCase( 3, actual:exA , expected:null, message:"M" , expectedMessage: string.Format("Assert failed.{0}Expected: (null){0}Actual: <System.ApplicationException>{0}M{0}Actual Exception: " + exA, Environment.NewLine)),
-                TestCase( 4, actual:null, expected:exB , message:"M" , expectedMessage: string.Format("Assert failed.{0}Expected: <System.Exception>{0}Actual: (null){0}M", Environment.NewLine)),
+                TestCase( 0, actual:exA , expectedType:typeof(ApplicationException), message:"M" , expectedMessage: null),
+                TestCase( 1, actual:exA , expectedType:typeof(Exception)           , message:"M" , expectedMessage: string.Format("Assert failed.{0}Expected: <System.Exception>{0}Actual: <System.ApplicationException>{0}M{0}Actual Exception: " + exA, Environment.NewLine)),
+                TestCase( 2, actual:exA , expectedType:typeof(Exception)           , message:null, expectedMessage: string.Format("Assert failed.{0}Expected: <System.Exception>{0}Actual: <System.ApplicationException>{0}{0}Actual Exception: " + exA, Environment.NewLine)),
+                TestCase( 3, actual:exA , expectedType:null                        , message:"M" , expectedMessage: string.Format("Assert failed.{0}Expected: (null){0}Actual: <System.ApplicationException>{0}M{0}Actual Exception: " + exA, Environment.NewLine)),
+                TestCase( 4, actual:null, expectedType:typeof(Exception)           , message:"M" , expectedMessage: string.Format("Assert failed.{0}Expected: <System.Exception>{0}Actual: (null){0}M", Environment.NewLine)),
             }) { action(); }
         }
 

--- a/tests/Inasync.TestAA.Tests/Usage.cs
+++ b/tests/Inasync.TestAA.Tests/Usage.cs
@@ -32,7 +32,7 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void ThrowsException() {
-            TestAA.Act(() => int.Parse("abc")).Assert(ret => { }, exception: new FormatException());
+            TestAA.Act(() => int.Parse("abc")).Assert<FormatException>();
         }
 
         [TestMethod]
@@ -59,7 +59,7 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void TaskThrowsException() {
-            TestAA.Act(() => Task.FromException(new ApplicationException())).Assert(new ApplicationException());
+            TestAA.Act(() => Task.FromException(new ApplicationException())).Assert<ApplicationException>();
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void ImmediateEnumerableEvaluation() {
-            TestAA.Act(() => CreateEnumerable()).Assert(ret => { }, new ApplicationException());
+            TestAA.Act(() => CreateEnumerable()).Assert<ApplicationException>();
 
             IEnumerable<int> CreateEnumerable() {
                 yield return 123;
@@ -80,15 +80,15 @@ namespace Inasync.Tests {
 
         [TestMethod]
         public void TestCases() {
-            Action TestCase(int testNumber, string input, int expected, Exception expectedException = null) => () => {
+            Action TestCase(int testNumber, string input, int expected, Type expectedException = null) => () => {
                 var msg = "No." + testNumber;
 
                 TestAA.Act(() => int.Parse(input)).Assert(expected, expectedException, msg);
             };
 
             foreach (var action in new[] {
-                TestCase( 0, null , expected: 0  , expectedException: new ArgumentNullException()),
-                TestCase( 1, "abc", expected: 0  , expectedException: new FormatException()),
+                TestCase( 0, null , expected: 0  , expectedException: typeof(ArgumentNullException)),
+                TestCase( 1, "abc", expected: 0  , expectedException: typeof(FormatException)),
                 TestCase( 2, "123", expected: 123),
             }) { action(); }
         }

--- a/tests/Inasync.TestAA.Tests/Usage.cs
+++ b/tests/Inasync.TestAA.Tests/Usage.cs
@@ -55,17 +55,20 @@ namespace Inasync.Tests {
         [TestMethod]
         public void TaskSynchronously() {
             TestAA.Act(() => Task.FromResult(123)).Assert(123);
+            TestAA.Act(() => new ValueTask<int>(123)).Assert(123);
         }
 
         [TestMethod]
         public void TaskThrowsException() {
             TestAA.Act(() => Task.FromException(new ApplicationException())).Assert<ApplicationException>();
+            TestAA.Act(() => new ValueTask(Task.FromException(new ApplicationException()))).Assert<ApplicationException>();
         }
 
         [TestMethod]
         public void RawTask() {
             var task = Task.FromResult(123);
             TestAA.Act<Task<int>>(() => task).Assert(task);
+            TestAA.Act<ValueTask<int>>(() => new ValueTask<int>(123)).Assert(new ValueTask<int>(123));
         }
 
         [TestMethod]


### PR DESCRIPTION
Resolve #5, #6
* 戻り値が ValueTask の act を受け取る Act() オーバーロードを追加。
* 戻り値の検証をスキップし例外検証のみ行う TestActual.Assert() オーバーロードを追加。
* 簡易例外検証にインスタンスではなく例外型を使用するよう変更。